### PR TITLE
Add a test script to test `xcp-ng-rpms` repos build

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # test-rpm-build
 Test script for the build of `xcp-ng-rpms` repos
+
+## How to
+
+This test is designed to be launched by github workflows to validate PRs on RPMs repos.
+However it can be launched manually and locally as follows:
+```
+TARGET_XCP_NG_VERSION=8.2 CONTAINER_NAME=container-name /path/to/this/repo/test-rpm-build.sh /path/to/rpm/repo
+```

--- a/test-rpm-build.sh
+++ b/test-rpm-build.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+
+# $1: Path to a `xcp-ng-rpms` repo to test its build
+# TARGET_XCP_NG_VERSION: env var used to define the XCP-ng version to used (eg: 8.2)
+# CONTAINER_NAME: env var used to define the name of the container created by the env builder
+
+set -eux
+
+BUILD_ENV_PATH=/tmp/build-env
+mkdir -p "$BUILD_ENV_PATH"
+
+git clone git@github.com:xcp-ng/xcp-ng-build-env.git "$BUILD_ENV_PATH"
+
+TARGET_XCP_NG_VERSION=${TARGET_XCP_NG_VERSION:-8.2}
+"$BUILD_ENV_PATH"/build.sh "$TARGET_XCP_NG_VERSION"
+
+REPO_PATH="$1"
+
+CONTAINER_NAME=${CONTAINER_NAME:-build-env}
+ADDITIONAL_REPOS=xcp-ng-staging
+python "$BUILD_ENV_PATH"/run.py --name "$CONTAINER_NAME" \
+    --fail-on-error \
+    --enablerepo "$ADDITIONAL_REPOS" \
+    -l "$REPO_PATH" \
+    -b "$TARGET_XCP_NG_VERSION" \
+    --rm
+
+rm -rf "$BUILD_ENV_PATH"


### PR DESCRIPTION
The script clone `xcp-ng/xcp-ng-build-env` and then:
- build the XCP-ng env container (8.2 by default but can be overriden)
- build and test the rpm given as argument following its specfile

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>