### PR TITLE
Create reusable GH workflow to test RPM build on new PR commit

### DIFF
--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -11,7 +11,6 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Build RPM
-      shell: 'script -q -e -c "bash {0}"'
       run: |
         git describe --always --dirty
         git clone https://github.com/xcp-ng-rpms/test-rpm-build.git /tmp/test-rpm-build

--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -1,0 +1,19 @@
+on: [workflow_call]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        lfs: true
+        fetch-depth: 0
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Build RPM
+      shell: 'script -q -e -c "bash {0}"'
+      run: |
+        git clone https://github.com/xcp-ng-rpms/test-rpm-build.git /tmp/test-rpm-build
+        GIT_DESCRIBE=$(git describe --tags)
+        VERSION=${GIT_DESCRIBE:0:3}
+        TARGET_XCP_NG_VERSION=$VERSION /tmp/test-rpm-build/test-rpm-build.sh .

--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -11,6 +11,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Build RPM
+      shell: 'script -q -e -c "bash {0}"'
       run: |
         /usr/bin/git describe --always --dirty
         git clone https://github.com/xcp-ng-rpms/test-rpm-build.git /tmp/test-rpm-build

--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -12,7 +12,7 @@ jobs:
       uses: actions/setup-python@v2
     - name: Build RPM
       run: |
-        git describe --always --dirty
+        /usr/bin/git describe --always --dirty
         git clone https://github.com/xcp-ng-rpms/test-rpm-build.git /tmp/test-rpm-build
         GIT_DESCRIBE=$(git describe --tags)
         VERSION=${GIT_DESCRIBE:0:3}

--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -13,6 +13,7 @@ jobs:
     - name: Build RPM
       shell: 'script -q -e -c "bash {0}"'
       run: |
+        git fetch --prune --unshallow --tags
         git clone https://github.com/xcp-ng-rpms/test-rpm-build.git /tmp/test-rpm-build
         GIT_DESCRIBE=$(git describe --tags)
         VERSION=${GIT_DESCRIBE:0:3}

--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -7,7 +7,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         lfs: true
-        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Build RPM

--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -7,6 +7,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         lfs: true
+        fetch-depth: 0
     - name: Set up Python
       uses: actions/setup-python@v2
     - name: Build RPM

--- a/.github/workflows/test-rpm-build.yaml
+++ b/.github/workflows/test-rpm-build.yaml
@@ -13,7 +13,7 @@ jobs:
     - name: Build RPM
       shell: 'script -q -e -c "bash {0}"'
       run: |
-        git fetch --prune --unshallow --tags
+        git describe --always --dirty
         git clone https://github.com/xcp-ng-rpms/test-rpm-build.git /tmp/test-rpm-build
         GIT_DESCRIBE=$(git describe --tags)
         VERSION=${GIT_DESCRIBE:0:3}


### PR DESCRIPTION
The workflow copy the [test-rpm-build](https://github.com/xcp-ng-rpms/test-rpm-build/) repo and run its test script.

Assume the git describe will respect the format: `<XCP-ng Version>-<nb of ahead commits>-<hash>`
It means a previous XCP-ng release must be tagged in the history tree.

This worflow will be called by others in the rpms repo.

Signed-off-by: BenjiReis <benjamin.reis@vates.fr>